### PR TITLE
Bug fixes

### DIFF
--- a/C/linkedlist.c
+++ b/C/linkedlist.c
@@ -12,7 +12,7 @@ void insert(){
 	struct node *new , *ptr;
 	int a;
 
-	new = (struct new *) malloc (sizeof(struct node));
+	new = (struct node *) malloc (sizeof(struct node));
 
 		printf("Enter the value to be Inserted : ");
 		scanf("%d" , &a);
@@ -39,12 +39,12 @@ void insert(){
 	}
 }
 
-insert_beg(){
+void insert_beg(){
 
 	struct node *new , *temp;
 	int a;
 
-	new = (struct new *) malloc (sizeof(struct node));
+	new = (struct node *) malloc (sizeof(struct node));
 
 	printf("Enter the value to be Inserted at the Beginning : ");
 	scanf("%d" , &a);
@@ -77,7 +77,7 @@ void insert_btw(){
 	printf("Enter the value to be Inserted : ");
 	scanf("%d" , &a);
 
-	new = (struct new *) malloc (sizeof(struct node));
+	new = (struct node *) malloc (sizeof(struct node));
 
 	new -> val = a;
 	new -> link = NULL;
@@ -125,6 +125,12 @@ void delete_last(){
 
 	struct node *ptr , *temp;
 
+    if (start->link == NULL) {
+        free(start);
+        start = NULL;
+        return;
+    }
+
 	ptr = start;
 
 	while(ptr -> link != NULL){
@@ -148,6 +154,11 @@ void delete_btw(){
 
 	printf("Enter the position where you want to delete the node : ");
 	scanf("%d" , &p);
+
+	if (p == 1) {
+        delete_beg();
+        return;
+    }
 
 	ptr = start;
 

--- a/C/logicalshift.c
+++ b/C/logicalshift.c
@@ -3,13 +3,12 @@
 
 int shift(int x , int n)
 {
-    x = x >> n;
-    x = x & ~(((1 << 31) >> n) << 1);
-    return x;
+    unsigned int mask = ~0U >> n;  // Create a mask of 1's with n trailing 0's
+    return (x >> n) & mask;
 }
 	
 
-void main(int agrc , char* argv[])
+void main(int argc , char* argv[])
 {
 
     int x , n;

--- a/C/stack_array.c
+++ b/C/stack_array.c
@@ -6,9 +6,10 @@ int top = -1 , *arr , n;
 void push(int x)
 {
     if(top == ((n / 2) - 1)){
-	arr = (int*)realloc(arr , (2 * n * sizeof(int)));
-	n = n * 2;
-	printf("Double Memory Allocated\n");
+        int *new_arr = (int *)realloc(arr, (2 * n * sizeof(int)));
+        arr = new_arr;
+        n = n * 2;
+        printf("Double Memory Allocated\n");
     }
     arr[++top] = x;
 }
@@ -16,7 +17,8 @@ void push(int x)
 int pop()
 {
     if(top == -1){
-	printf("Stack Empty\n");
+	    printf("Stack Empty\n");
+        return -1;
     }
 
     else{
@@ -35,40 +37,50 @@ void print()
     }
 }
 
-void main(int argc , char* argv[])
-{
-
-    int a , temp , y = 1;
-
-    sscanf(argv[1] , "%d" , &n);
-    arr = (int*)malloc(n * sizeof(int));
-
-    while(y == 1){
-
-    printf("Enter Your Choice : \n1.Push\n2.Pop\n3.Print : ");
-    scanf("%d" , &a);
-
-    switch(a){
-
-	case 1:{
-	    printf("Enter Element : ");
-	    scanf("%d" , &temp);
-	    push(temp);
-	    break;
-	}
-
-	case 2:{
-	    pop();
-	    break;
-	}
-
-	case 3:{
-	    print();
-	}
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <initial_size>\n", argv[0]);
+        return 1;
     }
 
-    printf("You want to continue ? 1 / 0 : ");
-    scanf("%d" , &y);
-  }
+    int a, temp, y = 1;
+    sscanf(argv[1], "%d", &n);
+    arr = (int *)malloc(n * sizeof(int));
+    if (arr == NULL) {
+        fprintf(stderr, "Memory allocation failed\n");
+        return 1;
+    }
 
+    while (y == 1) {
+        printf("Enter Your Choice:\n1. Push\n2. Pop\n3. Print\nChoice: ");
+        scanf("%d", &a);
+
+        switch (a) {
+            case 1:
+                printf("Enter Element: ");
+                scanf("%d", &temp);
+                push(temp);
+                break;
+            case 2:
+                if (top == -1)
+                    printf("Stack Empty\n");
+                else
+                    printf("Popped Element: %d\n", pop());
+                break;
+            case 3:
+                print();
+                printf("\n");
+                break;
+            default:
+                printf("Invalid Choice\n");
+        }
+
+        printf("Do you want to continue? (1/0): ");
+        scanf("%d", &y);
+    }
+
+    // Free allocated memory before program exit
+    free(arr);
+
+    return 0;
 }

--- a/C/stack_linked.c
+++ b/C/stack_linked.c
@@ -30,13 +30,20 @@ void push(int a)
 
 void pop()
 {
-    struct node* ptr = start , * save;
+    struct node* ptr = start;
+	struct node* save = NULL; 
     while(ptr -> next != NULL){
 	save = ptr;
 	ptr = ptr -> next;
     }
 
-    save -> next = NULL;
+    if (save == NULL) {
+        start = NULL;
+    } else {
+        save->next = NULL;
+    }
+
+	free(ptr);
 }
 
 void print()


### PR DESCRIPTION
Fixed:

- `linkedlist.c`:63:3: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]. Function `insert_beg` wasnt declared as `void`.
- `linkedlist.c`:136:2: error: Uninitialized variable: temp [uninitvar]. `start` was uninitialized.
- `linkedlist.c`:168:2: error: Uninitialized variable: prev [uninitvar]. `prev` was uninitialized.
- Changed `new = (struct new *) malloc (sizeof(struct node));` to `new = (struct node *) malloc (sizeof(struct node));` to fix the warnings `warning: assignment to ‘struct node *’ from incompatible pointer type ‘struct new *`
- `logicalshift.c`:7:19: error: Signed integer overflow for expression '1<<31'. [integerOverflow]. Fixed it by using ` unsigned int mask = ~0U >> n;`.
- `stack_array.c`:19:2: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]. Added a `return` and changed it, so it doesnt get a segfault.
- `stack_linked.c`:39:5: error: Uninitialized variable: save [uninitvar]. I initialized `save` to `NULL`.